### PR TITLE
MaskedField event target should emit a name and id attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1 (Feb 27, 2019)
+
+### Changes
+* Calling onChange will now return an event target that will also include id and name
+
 ## 2.0.0 (Oct 2, 2018)
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-masked-field",
   "description": "A masked field component built in React",
   "author": "Rylan Collins <rylan@gusto.com>",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/spec/MaskedField_spec.tsx
+++ b/spec/MaskedField_spec.tsx
@@ -23,6 +23,8 @@ console.error = (message: string) => {
 };
 
 interface TestProps {
+  id?: string;
+  name?: string;
   mask?: string;
   value?: string;
   onChange?: sinon.SinonSpy;
@@ -39,7 +41,7 @@ describe('MaskedField', () => {
   let container: HTMLDivElement;
   let component: ReactWrapper;
   let domNode: HTMLInputElement;
-  const props: TestProps = {};
+  const props: TestProps = { id: 'masked-field', name: 'masked_field' };
 
   // FIXME:
   // - undo?
@@ -130,6 +132,8 @@ describe('MaskedField', () => {
               expect(props.onChange).to.have.callCount(1);
               expect(props.onChange).to.have.been.calledWithExactly({
                 target: {
+                  id: props.id,
+                  name: props.name,
                   value: '2_/__/____',
                 },
               });
@@ -470,6 +474,8 @@ describe('MaskedField', () => {
               expect(props.onChange).to.have.callCount(1);
               expect(props.onChange).to.have.been.calledWithExactly({
                 target: {
+                  id: props.id,
+                  name: props.name,
                   value: '12/34/5___',
                 },
               });
@@ -908,7 +914,7 @@ describe('MaskedField', () => {
       if (props.value && !props.onChange) {
         props.readOnly = true;
       }
-      component = render(<MaskedField {...props} />);
+      component = render(<MaskedField id="masked-field" name="masked_field" {...props} />);
       domNode = inputNode();
     });
 
@@ -987,7 +993,7 @@ describe('MaskedField', () => {
       handleChange: MaskedFieldProps['onChange'] = e => {
         const { onChange } = this.props;
         if (onChange) {
-          onChange({ target: { value: e.target.value } });
+          onChange(e);
         }
         this.setState({ value: e.target.value });
       };
@@ -1003,7 +1009,7 @@ describe('MaskedField', () => {
     });
 
     beforeEach(() => {
-      component = render(<ControlledWrapper {...props} />);
+      component = render(<ControlledWrapper id="masked-field" name="masked_field" {...props} />);
       domNode = inputNode();
     });
 
@@ -1090,7 +1096,7 @@ describe('MaskedField', () => {
     }
 
     beforeEach(() => {
-      component = render(<LinkWrapper mask="99/99/9999" value={initialVal} />);
+      component = render(<LinkWrapper id='id' name='name' mask="99/99/9999" value={initialVal} />);
       domNode = inputNode();
       return simulateFocus();
     });
@@ -1147,7 +1153,7 @@ describe('MaskedField', () => {
         return (
           <div>
             <input onChange={this.onChange} />
-            <MaskedField mask="99-99-9999" />
+            <MaskedField id="masked-field" name="masked_field" mask="99-99-9999" />
           </div>
         );
       }

--- a/spec/MaskedField_spec.tsx
+++ b/spec/MaskedField_spec.tsx
@@ -22,19 +22,11 @@ console.error = (message: string) => {
   throw new Error(message);
 };
 
-interface TestProps {
-  id?: string;
-  name?: string;
-  mask?: string;
-  value?: string;
+interface TestProps extends MaskedFieldProps {
   onChange?: sinon.SinonSpy;
   onComplete?: sinon.SinonSpy;
   onKeyDown?: sinon.SinonSpy;
   onKeyPress?: sinon.SinonSpy;
-  readOnly?: boolean;
-  placeholder?: string;
-  translations?: MaskedFieldProps['translations'];
-  inputRef?: (node: HTMLInputElement | null) => any;
 }
 
 describe('MaskedField', () => {
@@ -1096,7 +1088,7 @@ describe('MaskedField', () => {
     }
 
     beforeEach(() => {
-      component = render(<LinkWrapper id='id' name='name' mask="99/99/9999" value={initialVal} />);
+      component = render(<LinkWrapper id="id" name="name" mask="99/99/9999" value={initialVal} />);
       domNode = inputNode();
       return simulateFocus();
     });

--- a/src/AlwaysMaskedField.tsx
+++ b/src/AlwaysMaskedField.tsx
@@ -20,6 +20,8 @@ const BLANK_CHAR = '_';
 type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export interface AlwaysMaskedFieldProps extends InputProps {
+  id: string;
+  name: string;
   mask: string;
   translations?: {
     [char: string]: RegExp;
@@ -30,7 +32,7 @@ export interface AlwaysMaskedFieldProps extends InputProps {
     value: string;
     requestChange: (newVal: string) => void;
   };
-  onChange?: (e: { target: { value: string } }) => void;
+  onChange?: (e: { target: { id: string, name: string, value: string } }) => void;
   inputRef?: (node: HTMLInputElement | null) => any;
 }
 
@@ -257,11 +259,11 @@ class AlwaysMaskedField extends React.Component<AlwaysMaskedFieldProps, MaskedFi
   }
 
   private callOnChange(value: string) {
-    const { valueLink, onChange } = this.props;
+    const { id, name, valueLink, onChange } = this.props;
     if (valueLink) {
       valueLink.requestChange(value);
     } else if (onChange) {
-      onChange({ target: { value } });
+      onChange({ target: { id, name, value } });
     }
   }
 

--- a/src/AlwaysMaskedField.tsx
+++ b/src/AlwaysMaskedField.tsx
@@ -20,8 +20,6 @@ const BLANK_CHAR = '_';
 type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export interface AlwaysMaskedFieldProps extends InputProps {
-  id: string;
-  name: string;
   mask: string;
   translations?: {
     [char: string]: RegExp;
@@ -32,7 +30,7 @@ export interface AlwaysMaskedFieldProps extends InputProps {
     value: string;
     requestChange: (newVal: string) => void;
   };
-  onChange?: (e: { target: { id: string, name: string, value: string } }) => void;
+  onChange?: (e: { target: { id?: string; name?: string; value: string } }) => void;
   inputRef?: (node: HTMLInputElement | null) => any;
 }
 


### PR DESCRIPTION
As part of the Formik project in component-library, MaskedField component needs to emit an event target that includes a name and id because Formik relies on the name (and the id as a backup) to update field values. We leverage MaskedField in component-library components such as Text for SSNs and phone numbers.