### PR TITLE
Fixes infinite loop bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.3 (Jan 08, 2020)
+
+### Bug Fixes
+* Fixes an infinite loop when retroactively adding input
+
 ## 2.0.2 (Feb 27, 2019)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-masked-field",
   "description": "A masked field component built in React",
   "author": "Rylan Collins <rylan@gusto.com>",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/spec/MaskedField.test.tsx
+++ b/spec/MaskedField.test.tsx
@@ -258,6 +258,33 @@ describe('MaskedField', () => {
               });
             });
           });
+
+          describe('all characters except first are added, and then first character is added', () => {
+            beforeEach(() => {
+              setSelection(1, 1);
+              simulateKeyPress('2');
+              setSelection(2, 2);
+              simulateKeyPress('2');
+              setSelection(3, 3);
+              simulateKeyPress('2');
+              setSelection(4, 4);
+              simulateKeyPress('2');
+              setSelection(5, 5);
+              simulateKeyPress('2');
+              setSelection(6, 6);
+              simulateKeyPress('2');
+              setSelection(7, 7);
+              simulateKeyPress('2');
+            });
+
+            it('inserts characters correctly and does not infinitely loop', () => {
+              expect(getFieldValue()).toEqual('_2/22/2222');
+
+              setSelection(0, 0);
+              simulateKeyPress('2');
+              expect(getFieldValue()).toEqual('2_/22/2222');
+            });
+          });
         });
 
         describe('pressing the backspace key', () => {

--- a/src/AlwaysMaskedField.tsx
+++ b/src/AlwaysMaskedField.tsx
@@ -299,10 +299,12 @@ class AlwaysMaskedField extends React.Component<AlwaysMaskedFieldProps, MaskedFi
           if (c === this.buffer[bufferIdx]) {
             bufferIdx += 1;
           } else if (pattern.test(c)) {
-            while (this.buffer[bufferIdx] !== '_') {
+            while (this.buffer[bufferIdx] !== '_' && bufferIdx < this.buffer.length) {
               bufferIdx += 1;
             }
-            this.buffer[bufferIdx] = c;
+            if (this.buffer[bufferIdx] !== undefined) {
+              this.buffer[bufferIdx] = c;
+            }
             break;
           } else if (this.cursorPos > lastPatternIdx) {
             this.cursorPos -= 1;


### PR DESCRIPTION
If you start typing from index 1 to the end of the mask, and then go back to type at index 0, an infinite loop occurs and the browser crashes. This happens in other scenarios too (e.g. last 3 chars, then enter the 4th to last char).

I haven't been able to manually test this locally by importing the local module into a project and hooking it up - I'm just going off of tests here.