### PR TITLE
fix: Correctly change value to be optional

### DIFF
--- a/src/AlwaysMaskedField.tsx
+++ b/src/AlwaysMaskedField.tsx
@@ -27,7 +27,7 @@ export interface AlwaysMaskedFieldProps extends InputProps {
   value?: string;
   onComplete?: (val: string) => void;
   valueLink?: {
-    value: string;
+    value?: string;
     requestChange: (newVal: string) => void;
   };
   onChange?: (e: { target: { id?: string; name?: string; value: string } }) => void;


### PR DESCRIPTION
The `value` field of the ValueLink object should be optional, like the `value` field is if no `valueLink` object is passed.
